### PR TITLE
feat(planner): add cost-aware planning

### DIFF
--- a/lib/planner/expand.ts
+++ b/lib/planner/expand.ts
@@ -1,0 +1,248 @@
+import type { Operation as PatchOperation } from 'mahler-wasm';
+import { diff as createPatch, patch as applyPatch } from 'mahler-wasm';
+
+import assert from '../assert';
+import type { Distance } from '../distance';
+import { Ref } from '../ref';
+import type { Action, Instruction } from '../task';
+import { Method, MethodExpansion } from '../task';
+import { PlanAction } from './node';
+import type { Plan } from './plan';
+import type { PlannerConfig } from './types';
+import { Aborted, ConditionNotMet, LoopDetected } from './types';
+import * as DAG from '../dag';
+import type { Operation } from '../operation';
+
+export interface PlanningState<TState = any> {
+	distance: Distance<TState>;
+	tasks: any[];
+	depth?: number;
+	operation?: Operation<TState, any>;
+	trace: PlannerConfig<TState>['trace'];
+	initialPlan: Plan<TState>;
+	callStack?: Array<Method<TState>>;
+	maxSearchDepth: number;
+}
+
+function tryAction<TState = any>(
+	action: Action<TState>,
+	{ initialPlan, callStack = [] }: PlanningState<TState>,
+): Plan<TState> {
+	assert(initialPlan.success);
+
+	const node = PlanAction.from(initialPlan.state, action);
+	const id = node.id;
+
+	if (
+		DAG.find(initialPlan.start, (a: PlanAction<TState>) => a.id === id) != null
+	) {
+		return { success: false, stats: initialPlan.stats, error: LoopDetected };
+	}
+
+	const ref = Ref.of(structuredClone(initialPlan.state));
+	action.effect(ref);
+	const state = ref._;
+
+	const changes = createPatch(initialPlan.state, state);
+
+	if (changes.length === 0 && callStack.length === 0) {
+		return initialPlan;
+	}
+
+	const start = DAG.createValue({
+		id,
+		action,
+		duration: node.duration,
+		next: initialPlan.start,
+	});
+
+	return {
+		success: true,
+		start,
+		stats: initialPlan.stats,
+		state,
+		pendingChanges: initialPlan.pendingChanges.concat(changes),
+	};
+}
+
+function trySequential<TState = any>(
+	method: Method<TState>,
+	{
+		initialPlan,
+		callStack = [],
+		maxSearchDepth,
+		...pState
+	}: PlanningState<TState>,
+): Plan<TState> {
+	assert(initialPlan.success);
+
+	if (callStack.length > maxSearchDepth) {
+		throw new Aborted(
+			`Maximum search depth ${maxSearchDepth} reached on recursion`,
+			initialPlan.stats,
+		);
+	}
+
+	const output = method(initialPlan.state);
+	const instructions = Array.isArray(output) ? output : [output];
+
+	const plan: Plan<TState> = { ...initialPlan };
+	const cStack = [...callStack, method];
+	for (const i of instructions) {
+		const res = expandInstruction(i, {
+			...pState,
+			initialPlan: plan,
+			callStack: cStack,
+			maxSearchDepth,
+			trace: pState.trace,
+		});
+		if (!res.success) {
+			return res;
+		}
+		plan.start = res.start;
+		plan.state = res.state;
+		plan.pendingChanges = res.pendingChanges;
+	}
+
+	return plan;
+}
+
+function findConflict(
+	ops: PatchOperation[][],
+): [PatchOperation, PatchOperation] | undefined {
+	const unique = new Map<string, [number, PatchOperation]>();
+
+	for (const [i, patches] of ops.entries()) {
+		for (const o of patches) {
+			for (const [path, [index, op]] of unique.entries()) {
+				if (
+					i !== index &&
+					(o.path.startsWith(path) || path.startsWith(o.path))
+				) {
+					return [o, op];
+				}
+			}
+			unique.set(o.path, [i, o]);
+		}
+	}
+}
+
+function tryParallel<TState = any>(
+	parallel: Method<TState>,
+	{
+		trace,
+		initialPlan,
+		callStack = [],
+		maxSearchDepth,
+		...pState
+	}: PlanningState<TState>,
+): Plan<TState> {
+	assert(initialPlan.success);
+
+	if (callStack.length > maxSearchDepth) {
+		throw new Aborted(
+			`Maximum search depth ${maxSearchDepth} reached on recursion`,
+			initialPlan.stats,
+		);
+	}
+	const output = parallel(initialPlan.state);
+	const instructions = Array.isArray(output) ? output : [output];
+
+	if (instructions.length === 0) {
+		return initialPlan;
+	}
+
+	const empty = DAG.createJoin(initialPlan.start);
+
+	const results: Array<Plan<TState> & { success: true }> = [];
+	const cStack = [...callStack, parallel];
+	for (const i of instructions) {
+		const res = expandInstruction(i, {
+			...pState,
+			trace,
+			initialPlan: { ...initialPlan, start: empty },
+			callStack: cStack,
+			maxSearchDepth,
+		});
+
+		if (!res.success) {
+			return res;
+		}
+
+		results.push(res as any);
+	}
+
+	const patches = results.map((r) => r.pendingChanges);
+	const conflict = findConflict(patches);
+	if (conflict != null) {
+		trace({ event: 'parallel-conflict', conflict } as any);
+		return trySequential(parallel, {
+			trace,
+			initialPlan,
+			callStack,
+			maxSearchDepth,
+			...pState,
+		});
+	}
+
+	const start = DAG.createFork(
+		results.map((r) => r.start!).filter((r) => r != null),
+	);
+
+	const pendingChanges = results.reduce(
+		(acc, r) => acc.concat(r.pendingChanges),
+		initialPlan.pendingChanges,
+	);
+
+	const state = applyPatch(structuredClone(initialPlan.state), pendingChanges);
+
+	return {
+		success: true,
+		state,
+		pendingChanges,
+		start,
+		stats: initialPlan.stats,
+	};
+}
+
+export function expandInstruction<TState = any>(
+	instruction: Instruction<TState>,
+	{ trace, initialPlan, callStack = [], ...state }: PlanningState<TState>,
+): Plan<TState> {
+	assert(initialPlan.success);
+	trace({
+		event: 'try-instruction',
+		operation: state.operation!,
+		parent: callStack[callStack.length - 1],
+		instruction,
+		state: initialPlan.state,
+		prev: initialPlan.start,
+	});
+
+	if (!instruction.condition(initialPlan.state)) {
+		return { success: false, stats: initialPlan.stats, error: ConditionNotMet };
+	}
+
+	let res: Plan<TState>;
+	if (Method.is(instruction)) {
+		if (instruction.expansion === MethodExpansion.SEQUENTIAL) {
+			res = trySequential(instruction, {
+				...state,
+				trace,
+				initialPlan,
+				callStack,
+			});
+		} else {
+			res = tryParallel(instruction, {
+				...state,
+				trace,
+				initialPlan,
+				callStack,
+			});
+		}
+	} else {
+		res = tryAction(instruction, { ...state, trace, initialPlan, callStack });
+	}
+
+	return res;
+}

--- a/lib/planner/findBestPlan.spec.ts
+++ b/lib/planner/findBestPlan.spec.ts
@@ -1,0 +1,41 @@
+import { expect, log } from '~/test-utils';
+import { Planner } from '.';
+import { Task } from '../task';
+import { plan, stringify } from '../testing';
+
+describe('Planner.findBestPlan', () => {
+	it('chooses the plan with lower estimated cost', () => {
+		type State = { n: number };
+
+		const inc = Task.of<State>().from({
+			lens: '/n',
+			condition: (n, { target }) => n < target,
+			effect: (n) => {
+				n._ = n._ + 1;
+			},
+			description: 'inc',
+			estimate: 1,
+		});
+
+		const incFast = Task.of<State>().from({
+			lens: '/n',
+			condition: (n, { target }) => n < target,
+			effect: (n) => {
+				n._ = n._ + 2;
+			},
+			description: 'inc-fast',
+			estimate: 3,
+		});
+
+		const planner = Planner.from<State>({
+			tasks: [incFast, inc],
+			config: { trace: log },
+		});
+
+		const result = planner.findBestPlan({ n: 0 }, { n: 2 });
+		expect(result.success).to.be.true;
+		expect(stringify(result)).to.equal(
+			plan().action('inc').action('inc').end(),
+		);
+	});
+});

--- a/lib/planner/findBestPlan.ts
+++ b/lib/planner/findBestPlan.ts
@@ -1,0 +1,161 @@
+import { patch as applyPatch } from 'mahler-wasm';
+
+import { Distance } from '../distance';
+import { Lens } from '../lens';
+import { Pointer } from '../pointer';
+import type { Task } from '../task';
+import { expandInstruction } from './expand';
+import { sumDuration, makespan } from './metrics';
+import { isTaskApplicable } from './utils';
+import { Aborted, MethodExpansionEmpty, SearchFailed } from './types';
+import type { PlannerConfig } from './types';
+import type { Plan } from './plan';
+import type { Operation } from '../operation';
+
+type Objective = 'sum' | 'makespan' | ((start: any) => number);
+
+export interface BestPlanOptions {
+	objective?: Objective;
+	maxNodes?: number;
+	maxDepth?: number;
+	timeLimitMs?: number;
+	trace?: PlannerConfig<any>['trace'];
+}
+
+type Node<TState> = {
+	plan: Plan<TState> & { success: true };
+	g: number;
+	depth: number;
+};
+
+function score(start: any, objective: Objective): number {
+	if (typeof objective === 'function') {
+		return objective(start);
+	}
+	if (objective === 'makespan') {
+		return makespan(start);
+	}
+	return sumDuration(start);
+}
+
+export function findBestPlan<TState>(
+	current: TState,
+	target: any,
+	tasks: Array<Task<TState, any, any>>,
+	config: PlannerConfig<TState>,
+	opts: BestPlanOptions = {},
+): Plan<TState> {
+	const distance = Distance.from(current, target);
+	const trace =
+		opts.trace ??
+		config.trace ??
+		(() => {
+			/* noop */
+		});
+	const maxDepth = opts.maxDepth ?? config.maxSearchDepth ?? 1000;
+	const maxNodes = opts.maxNodes ?? Infinity;
+	const timeLimitMs = opts.timeLimitMs ?? Infinity;
+	const objective = opts.objective ?? 'sum';
+
+	const startPlan: Plan<TState> & { success: true } = {
+		success: true,
+		start: null,
+		state: current,
+		stats: { iterations: 0, maxDepth: 0, time: 0 },
+		pendingChanges: [],
+	};
+
+	const pq: Array<Node<TState>> = [{ plan: startPlan, g: 0, depth: 0 }];
+
+	const popBest = () => {
+		pq.sort((a, b) => a.g - b.g);
+		return pq.shift()!;
+	};
+
+	const started = performance.now();
+	let expanded = 0;
+
+	while (pq.length > 0) {
+		if (expanded++ > maxNodes) {
+			break;
+		}
+		if (performance.now() - started > timeLimitMs) {
+			break;
+		}
+
+		const cur = popBest();
+
+		const ops = distance(cur.plan.state);
+		if (ops.length === 0) {
+			trace({ event: 'found', prev: cur.plan.start });
+			return cur.plan;
+		}
+
+		if (cur.depth >= maxDepth) {
+			throw new Aborted(
+				`Maximum search depth reached (${maxDepth})`,
+				cur.plan.stats,
+			);
+		}
+
+		trace({
+			event: 'find-next',
+			depth: cur.depth,
+			state: cur.plan.state,
+			prev: cur.plan.start,
+			operations: ops,
+		});
+
+		for (const operation of ops) {
+			const applicable = tasks.filter((t) => isTaskApplicable(t, operation));
+			for (const t of applicable) {
+				cur.plan.stats.iterations++;
+				const path = operation.path;
+				const tgt =
+					operation.op === 'delete'
+						? undefined
+						: Pointer.from<TState, string>(distance.target, path);
+				const ctx = Lens.context<any, string>(t.lens, path, tgt);
+
+				const childDelta = expandInstruction((t as any)(ctx as any), {
+					distance,
+					tasks,
+					trace,
+					operation: operation as Operation<TState, any>,
+					initialPlan: cur.plan,
+					callStack: [],
+					depth: cur.depth,
+					maxSearchDepth: maxDepth,
+				});
+				if (!childDelta.success) {
+					trace(childDelta.error);
+					continue;
+				}
+				if (childDelta.start === cur.plan.start) {
+					trace(MethodExpansionEmpty);
+					continue;
+				}
+
+				const childState = applyPatch(
+					structuredClone(cur.plan.state),
+					childDelta.pendingChanges,
+				);
+
+				const base = score(cur.plan.start, objective);
+				const next = score(childDelta.start, objective);
+				const delta = next - base;
+
+				const childPlan: Plan<TState> & { success: true } = {
+					...childDelta,
+					state: childState,
+					pendingChanges: [],
+					stats: cur.plan.stats,
+				};
+				pq.push({ plan: childPlan, g: cur.g + delta, depth: cur.depth + 1 });
+			}
+		}
+	}
+
+	trace({ event: 'failed' });
+	return { success: false, stats: startPlan.stats, error: SearchFailed };
+}

--- a/lib/planner/findPlan.ts
+++ b/lib/planner/findPlan.ts
@@ -214,7 +214,7 @@ function tryParallel<TState = any>(
 	// having the fork and empty node, so we need to remove the empty node
 	// and connect the last action in the branch directly to the existing plan
 	if (results.length === 1) {
-		const branch = results[0]!;
+		const branch = results[0];
 		// Find the first node for which the next element is the
 		// empty node created earlier
 		const last = DAG.find(

--- a/lib/planner/index.ts
+++ b/lib/planner/index.ts
@@ -2,6 +2,8 @@ import { Distance } from '../distance';
 import type { Target } from '../target';
 import { Task } from '../task';
 import { findPlan } from './findPlan';
+import type { BestPlanOptions } from './findBestPlan';
+import { findBestPlan as _findBestPlan } from './findBestPlan';
 import type { PlannerConfig } from './types';
 import { Aborted } from './types';
 import type { Plan } from './plan';
@@ -11,6 +13,7 @@ import * as DAG from '../dag';
 export * from './types';
 export * from './plan';
 export * from './node';
+export type { BestPlanOptions } from './findBestPlan';
 
 export interface Planner<TState = any> {
 	/**
@@ -19,6 +22,11 @@ export interface Planner<TState = any> {
 	 * cannot be found.
 	 */
 	findPlan(current: TState, target: Target<TState>): Plan<TState>;
+	findBestPlan(
+		current: TState,
+		target: Target<TState>,
+		options?: BestPlanOptions,
+	): Plan<TState>;
 }
 
 function from<TState = any>({
@@ -95,6 +103,41 @@ function from<TState = any>({
 					trace(e);
 					trace({ event: 'failed' });
 
+					return { success: false, stats: e.stats, error: e };
+				}
+				throw e;
+			}
+		},
+		findBestPlan(
+			current: TState,
+			target: Target<TState>,
+			options: BestPlanOptions = {},
+		) {
+			current = structuredClone(current);
+			const time = performance.now();
+			trace({ event: 'start', target });
+			try {
+				const res = _findBestPlan(
+					current,
+					target,
+					tasks,
+					{ trace, maxSearchDepth },
+					options,
+				);
+				res.stats = { ...res.stats, time: performance.now() - time };
+				if (res.success) {
+					const start = DAG.reverse(res.start);
+					assert(!Array.isArray(start));
+					res.start = start;
+					trace({ event: 'success', start });
+				} else {
+					trace({ event: 'failed' });
+				}
+				return res;
+			} catch (e) {
+				if (e instanceof Aborted) {
+					trace(e);
+					trace({ event: 'failed' });
 					return { success: false, stats: e.stats, error: e };
 				}
 				throw e;

--- a/lib/planner/metrics.ts
+++ b/lib/planner/metrics.ts
@@ -1,0 +1,51 @@
+import type { PlanNode, PlanAction } from './node';
+import * as DAG from '../dag';
+
+export function sumDuration(start: PlanNode<any> | null): number {
+	const visited = new Set<PlanNode<any>>();
+	const stack: Array<PlanNode<any> | null> = [start];
+	let acc = 0;
+	while (stack.length > 0) {
+		const n = stack.pop();
+		if (!n || visited.has(n)) {
+			continue;
+		}
+		visited.add(n);
+		if ((n as any).action) {
+			acc += (n as PlanAction<any>).duration ?? 0;
+			stack.push((n as PlanAction<any>).next as any);
+		} else if (DAG.isFork(n)) {
+			for (const b of (n as any).next) {
+				stack.push(b);
+			}
+			stack.push((n as any).next);
+		} else if ((n as any)._tag === 'join') {
+			stack.push((n as any).next);
+		}
+	}
+	return acc;
+}
+
+export function makespan(start: PlanNode<any> | null): number {
+	const memo = new Map<PlanNode<any> | null, number>();
+	const longest = (n: PlanNode<any> | null): number => {
+		if (memo.has(n)) {
+			return memo.get(n)!;
+		}
+		let res = 0;
+		if (!n) {
+			res = 0;
+		} else if ((n as any).action) {
+			const a = n as PlanAction<any>;
+			res = (a.duration ?? 0) + longest(a.next as any);
+		} else if (DAG.isFork(n)) {
+			res = Math.max(0, ...(n as any).next.map((b: any) => longest(b)));
+			res = Math.max(res, longest((n as any).next));
+		} else if ((n as any)._tag === 'join') {
+			res = longest((n as any).next);
+		}
+		memo.set(n, res);
+		return res;
+	};
+	return longest(start);
+}

--- a/lib/planner/node.ts
+++ b/lib/planner/node.ts
@@ -21,6 +21,7 @@ export interface PlanAction<TState> extends DAG.Value {
 	 * The action to execute
 	 */
 	readonly action: Action<TState>;
+	readonly duration?: number;
 }
 
 export type PlanNode<TState> = PlanAction<TState> | Fork | Join;
@@ -57,9 +58,17 @@ export const PlanAction = {
 			)
 			.digest('hex');
 
+		const duration =
+			typeof a.estimate === 'function'
+				? Math.max(0, a.estimate(state, { target: a.target, path: a.path }))
+				: typeof a.estimate === 'number'
+					? Math.max(0, a.estimate)
+					: undefined;
+
 		return DAG.createValue({
 			id,
 			action: a,
+			duration,
 			next: null,
 		});
 	},

--- a/lib/task/instructions.ts
+++ b/lib/task/instructions.ts
@@ -3,6 +3,10 @@ import type { Context } from './context';
 import type { Ref } from '../ref';
 import type { AnyOp, Update, Create } from '../operation';
 
+export type Estimate<TState = any, Ctx = any> =
+	| number
+	| ((state: TState, ctx: Ctx) => number);
+
 interface Instance<TState, TPath extends PathType, TOp extends AnyOp> {
 	/**
 	 * The identifier for the task
@@ -30,6 +34,11 @@ interface Instance<TState, TPath extends PathType, TOp extends AnyOp> {
 	 * A pre-condition that needs to be met before the instance can be used
 	 */
 	condition(s: TState): boolean;
+
+	/**
+	 * Optional estimate of the cost of running this instruction
+	 */
+	readonly estimate?: Estimate;
 }
 
 /** An action task that has been applied to a specific context */

--- a/lib/task/props.ts
+++ b/lib/task/props.ts
@@ -3,7 +3,7 @@ import type { AnyOp, Update, Create } from '../operation';
 import type { PathType, Root } from '../path';
 import type { View } from '../view';
 import type { Context } from './context';
-import type { Instruction, MethodExpansion } from './instructions';
+import type { Instruction, MethodExpansion, Estimate } from './instructions';
 import type { ReadOnly } from '../readonly';
 
 export type ContextWithSystem<
@@ -91,6 +91,11 @@ export interface ActionTaskProps<
 	description?: DescriptionFn<TState, TPath, TOp>;
 
 	/**
+	 * Optional cost estimate for this task
+	 */
+	estimate?: Estimate;
+
+	/**
 	 * A condition that must be met for the task to be chosen by the planner or executed by
 	 * an agent.
 	 */
@@ -167,6 +172,11 @@ export type MethodTaskProps<
 	 * be compared by their description (useful for testing and debugging).
 	 */
 	description?: DescriptionFn<TState, TPath, TOp>;
+
+	/**
+	 * Optional cost estimate for this task
+	 */
+	estimate?: Estimate;
 
 	/**
 	 * The method expansion. The default is 'detect', meaning the planner will try to execute

--- a/lib/task/tasks.ts
+++ b/lib/task/tasks.ts
@@ -9,7 +9,7 @@ import type { Ref } from '../ref';
 import { View } from '../view';
 import type { TaskArgs, TaskOp } from './context';
 import { Context } from './context';
-import type { Action, Instruction, Method } from './instructions';
+import type { Action, Estimate, Instruction, Method } from './instructions';
 import { MethodExpansion } from './instructions';
 import type {
 	ActionTaskProps,
@@ -53,6 +53,11 @@ interface TaskSpec<
 		s: Lens<TState, TPath>,
 		ctx: ContextWithSystem<TState, TPath, TOp>,
 	) => boolean;
+
+	/**
+	 * Optional cost estimate for this task
+	 */
+	readonly estimate?: Estimate;
 }
 
 /**
@@ -286,6 +291,7 @@ function ground<
 			_tag: 'action' as const,
 			description,
 			condition,
+			estimate: task.estimate,
 			effect,
 			toJSON() {
 				return {
@@ -312,6 +318,7 @@ function ground<
 		_tag: 'method' as const,
 		description,
 		condition,
+		estimate: task.estimate,
 		expansion,
 		toJSON() {
 			return {


### PR DESCRIPTION
## Summary
- allow actions and methods to carry cost estimates
- record action duration in plan nodes
- add best-first `findBestPlan` API for cost-aware search
- demonstrate with new planner test
- fix parallel expansion and state cloning during planning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd49987fe8832fbcdeacc572f8bf89